### PR TITLE
build the project in a nix-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ nix-build
 open ./result/bin/app.jsexe/index.html
 ```
 
+## Build the project in a nix-shell
+
+```sh
+nix-shell -A env
+cabal build
+open `find dist-newstyle/ -name index.html`
+```
+
 ## Update dependencies
 
 The `default.nix` file has a couple of lines which indicate the "state of the world" for the build system:

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,2 @@
+compiler: ghcjs
+


### PR DESCRIPTION
Hi,
When developing the project, I think it's better to build the project in a nix-shell (incremental build, same nix derivation...). This PR is a minor update for enabling that.