### PR TITLE
Stylistic Nix expression refactoring

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,102 +1,62 @@
 let
-  # Pin the Miso repository to a particular commit.
+  # Pin the Miso repository to a particular commit, import the expression, and
+  # retrieve the nixpkgs package set it provides.
   #
   # Last updated: 4 September 2020
-  misoSrc = builtins.fetchTarball {
-    url = "https://github.com/dmjio/miso/archive/bb230192164f0532660aadb4175460740abfa2a2.tar.gz";
-    sha256 = "0q44lxzz8pp89ccaiw3iwczha8x2rxjwmgzkxj8cxm97ymsm0diy";
-  };
+  pkgs = (
+    import (
+      builtins.fetchTarball {
+        url = "https://github.com/dmjio/miso/archive/bb230192164f0532660aadb4175460740abfa2a2.tar.gz";
+        sha256 = "0q44lxzz8pp89ccaiw3iwczha8x2rxjwmgzkxj8cxm97ymsm0diy";
+      }
+    ) {}
+  ).pkgs;
 
-  # Import the Miso expression and retrieve the pinned Nixpkgs set from it.
-  miso = import misoSrc {};
-  inherit (miso) pkgs;
+  # Construct a complete Haskell package set by overlaying the base package set
+  # from nixpkgs with various packages from external sources.
+  haskellPackages = pkgs.haskell.packages.ghcjs.override (
+    oldArgs: {
+      # Ensure that we have an up-to-date Hackage snapshot.
+      #
+      # Last updated: 4 September 2020.
+      all-cabal-hashes = pkgs.fetchurl {
+        url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/117622c10bf41f70548af023366ad82eab9835e3.tar.gz";
+        sha256 = "15zpi7x1iqkjk4dscm0z9xxshl58nmdi3sxgn8w3x86wbz03k1wv";
+      };
 
-  # Ensure that we have an up-to-date Hackage snapshot.
-  #
-  # This will act as our "base" Haskell package set, on top of which we can
-  # overlay additional packages from Hackage, GitHub, et al.
-  #
-  # Last updated: 4 September 2020.
-  hackageSnapshot = pkgs.haskell.packages.ghcjs.override {
-    all-cabal-hashes = pkgs.fetchurl {
-      url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/117622c10bf41f70548af023366ad82eab9835e3.tar.gz";
-      sha256 = "15zpi7x1iqkjk4dscm0z9xxshl58nmdi3sxgn8w3x86wbz03k1wv";
-    };
-  };
-
-  # Skip running the test suite for a Haskell project.
-  inherit (pkgs.haskell.lib) dontCheck;
-
-  # An overlay that overrides/augments a Haskell package set with additional
-  # Hackage packages.
-  #
-  # NOTE: 'callHackage' depends on 'all-cabal-hashes', and therefore cannot be
-  # used to retrieve Hackage packages that have been added _after_ that
-  # snapshot was taken.
-  #
-  # To depend on Hackage packages that were added after this snapshot was
-  # taken, use 'callHackageDirect' instead.
-  extraHackagePackages = hself: hsuper: {
-    servant = dontCheck (
-      hself.callHackage "servant" "0.16" {}
-    );
-    servant-client-core = dontCheck (
-      hself.callHackage "servant-client-core" "0.16" {}
-    );
-  };
-
-  # Skip version bounds checks for a Haskell project.
-  inherit (pkgs.haskell.lib) doJailbreak;
-
-  # An overlay that overrides/augments a Haskell package set with additional
-  # additional Haskell packages from external source repositories.
-  extraSourcePackages = hself: hsuper: {
-    servant-client-ghcjs =
-      let
-        # Fetch the entire 'haskell-servant' repository from GitHub.
-        srcRepo =
-          pkgs.fetchFromGitHub {
-            owner = "haskell-servant";
-            repo = "servant";
-            rev = "v0.16";
-            sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
-          };
-
-        # NOTE: 'servant-client-ghcjs' resides in a subdirectory of the
-        # 'haskell-servant' repository.
-        src = srcRepo + "/servant-client-ghcjs";
-      in
-        doJailbreak (hself.callCabal2nix "servant-client-ghcjs" src {});
-  };
-
-  # Helper function to apply a list of Haskell package set overlays that will
-  # override or augment the base snapshot with additional Haskell packages from
-  # Hackage or other sources.
-  applyOverlays = snapshot: overlays: snapshot.override (
-    oldSnapshot:
-      let
-        oldOverrides = oldSnapshot.overrides or (_:_: {});
-      in
-        {
-          overrides =
-            builtins.foldl'
-              pkgs.lib.composeExtensions
-              oldOverrides
-              overlays;
+      # Override/extend the base package set.
+      overrides = pkgs.lib.composeExtensions (oldArgs.overrides or (_: _: {})) (
+        hself: hsuper: {
+          servant = pkgs.haskell.lib.dontCheck (
+            hself.callHackage "servant" "0.16" {}
+          );
+          servant-client-core = pkgs.haskell.lib.dontCheck (
+            hself.callHackage "servant-client-core" "0.16" {}
+          );
+          servant-client-ghcjs =
+            let
+              src =
+                pkgs.fetchFromGitHub {
+                  owner = "haskell-servant";
+                  repo = "servant";
+                  rev = "v0.16";
+                  sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
+                } + "/servant-client-ghcjs";
+            in
+              pkgs.haskell.lib.doJailbreak (
+                hself.callCabal2nix "servant-client-ghcjs" src {}
+              );
         }
+      );
+    }
   );
-
-  # Construct a complete Haskell package set by overlaying the package set
-  # provided by 'hackageSnapshot' with the extensions from
-  # 'extraHackagePackages' and 'extraSourcePackages'.
-  #
-  # NOTE: The list of package set overrides is applied in-order; if there are
-  # conflicting packages across two or more package sets, the last set of
-  # overrides to be applied "wins".
-  haskellPackages = applyOverlays hackageSnapshot [
-    extraHackagePackages
-    extraSourcePackages
-  ];
 in
 
-haskellPackages.callCabal2nix "miso-app" ./. {}
+haskellPackages.developPackage {
+  # cf. https://nix.dev/anti-patterns/language.html#reproducability-referencing-top-level-directory-with
+  root = builtins.path {
+    path = ./.;
+    name = "miso-project";
+  };
+  name = "miso-app";
+}

--- a/default.nix
+++ b/default.nix
@@ -1,31 +1,88 @@
-with (import (builtins.fetchTarball {
-  # point to latest commit for miso
-  # last updated: 4 september 2020
-  url = "https://github.com/dmjio/miso/archive/bb230192164f0532660aadb4175460740abfa2a2.tar.gz";
-  sha256 = "0q44lxzz8pp89ccaiw3iwczha8x2rxjwmgzkxj8cxm97ymsm0diy";
-}) {});
 let
-  my-haskell-packages = (pkgs.haskell.packages.ghcjs.override {
-    # this ensures we have an up-to-date view of Hackage
-    # last updated: 4 september 2020
+  # Pin the Miso repository to a particular commit.
+  #
+  # Last updated: 4 September 2020
+  misoSrc = builtins.fetchTarball {
+    url = "https://github.com/dmjio/miso/archive/bb230192164f0532660aadb4175460740abfa2a2.tar.gz";
+    sha256 = "0q44lxzz8pp89ccaiw3iwczha8x2rxjwmgzkxj8cxm97ymsm0diy";
+  };
+
+  # Import the Miso expression and retrieve the pinned Nixpkgs set from it.
+  miso = import misoSrc {};
+  inherit (miso) pkgs;
+
+  # Ensure that we have an up-to-date Hackage snapshot.
+  #
+  # This will act as our "base" Haskell package set, on top of which we can
+  # overlay additional packages from Hackage, GitHub, et al.
+  #
+  # Last updated: 4 September 2020.
+  hackageSnapshot = pkgs.haskell.packages.ghcjs.override {
     all-cabal-hashes = pkgs.fetchurl {
       url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/117622c10bf41f70548af023366ad82eab9835e3.tar.gz";
       sha256 = "15zpi7x1iqkjk4dscm0z9xxshl58nmdi3sxgn8w3x86wbz03k1wv";
     };
-  }).extend (hself: hsuper: rec {
-    # include here packages not in the snapshot
-    # that you want to bring from Hackage
-    # -- servant client --
-    servant = pkgs.haskell.lib.dontCheck (hself.callHackage "servant" "0.16" {});
-    servant-client-core = pkgs.haskell.lib.dontCheck (hself.callHackage "servant-client-core" "0.16" {});
-  });
-  # these are packages only available in GitHub
-  servant-client-ghcjs-src = pkgs.fetchFromGitHub { 
-     owner = "haskell-servant";
-     repo = "servant";
-     rev = "v0.16";
-     sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
-  } + "/servant-client-ghcjs";
-  servant-client-ghcjs = my-haskell-packages.callCabal2nixWithOptions "servant-client-ghcjs" servant-client-ghcjs-src "--jailbreak" {};  # jailbreak means 'do not check bounds'
+  };
+
+  # Skip running the test suite for a Haskell project.
+  inherit (pkgs.haskell.lib) dontCheck;
+
+  # An overlay that overrides/augments a Haskell package set with additional
+  # Hackage packages.
+  #
+  # NOTE: 'callHackage' depends on 'all-cabal-hashes', and therefore cannot be
+  # used to retrieve Hackage packages that have been added _after_ that
+  # snapshot was taken.
+  #
+  # To depend on Hackage packages that were added after this snapshot was
+  # taken, use 'callHackageDirect' instead.
+  extraHackagePackages = hself: hsuper: {
+    servant = dontCheck (
+      hself.callHackage "servant" "0.16" {}
+    );
+    servant-client-core = dontCheck (
+      hself.callHackage "servant-client-core" "0.16" {}
+    );
+  };
+
+  # Skip version bounds checks for a Haskell project.
+  inherit (pkgs.haskell.lib) doJailbreak;
+
+  # An overlay that overrides/augments a Haskell package set with additional
+  # additional Haskell packages from external source repositories.
+  extraSourcePackages = hself: hsuper: {
+    servant-client-ghcjs =
+      let
+        src =
+          pkgs.fetchFromGitHub {
+            owner = "haskell-servant";
+            repo = "servant";
+            rev = "v0.16";
+            sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
+          }
+          # NOTE: 'servant-client-ghcjs' resides in a subdirectory of the
+          # 'haskell-servant' repository.
+          + "/servant-client-ghcjs";
+      in
+        doJailbreak (hself.callCabal2nix "servant-client-ghcjs" src {});
+  };
+
+  # Construct a complete Haskell package set by overlaying the package set
+  # provided by 'hackageSnapshot' with the extensions from
+  # 'extraHackagePackages' and 'extraSourcePackages'.
+  #
+  # NOTE: The list of package set overrides is applied in-order; if there are
+  # conflicting packages across two or more package sets, the last set of
+  # overrides to be applied "wins".
+  haskellPackages = hackageSnapshot.override (
+    old: {
+      overrides = builtins.foldl' pkgs.lib.composeExtensions
+        (old.overrides or (_: _: {})) [
+        extraHackagePackages
+        extraSourcePackages
+      ];
+    }
+  );
 in
-  my-haskell-packages.callCabal2nix "miso-app" ./. { inherit servant-client-ghcjs; }
+
+haskellPackages.callCabal2nix "miso-app" ./. {}

--- a/default.nix
+++ b/default.nix
@@ -53,16 +53,18 @@ let
   extraSourcePackages = hself: hsuper: {
     servant-client-ghcjs =
       let
-        src =
+        # Fetch the entire 'haskell-servant' repository from GitHub.
+        srcRepo =
           pkgs.fetchFromGitHub {
             owner = "haskell-servant";
             repo = "servant";
             rev = "v0.16";
             sha256 = "0dyn50gidzbgyq9yvqijnysai9hwd3srqvk8f8rykh09l375xb9j";
-          }
-          # NOTE: 'servant-client-ghcjs' resides in a subdirectory of the
-          # 'haskell-servant' repository.
-          + "/servant-client-ghcjs";
+          };
+
+        # NOTE: 'servant-client-ghcjs' resides in a subdirectory of the
+        # 'haskell-servant' repository.
+        src = srcRepo + "/servant-client-ghcjs";
       in
         doJailbreak (hself.callCabal2nix "servant-client-ghcjs" src {});
   };


### PR DESCRIPTION
This is very much a subjective/stylistic PR, so feel free to request significant changes or even close it entirely if you feel that it oversteps your intentions for this repo.

---

I saw this posted on r/haskell and figured that since it’s a template, it might end up in front of people who aren’t necessarily super familiar with Nix.

To that end, I’ve refactored the `default.nix` expression to lay things out in a way that I think might make it easier for others to grow and extend parts of the expression gracefully.

In particular, I’ve added:
- a few more intermediate variables to help outline the process of sourcing and transforming the package set
- a utility for combining package set overlays so that it’s easy to separate things out into logical groups
- patterns that can be extended to factor these extensions out into separate files if they grow large enough